### PR TITLE
fix: add not-a-toy to platform.ignore for breaking data

### DIFF
--- a/platform.ignore
+++ b/platform.ignore
@@ -23,3 +23,6 @@ dronebox
 
 # extra classes config has illegal char, but should just drop this and add classes normally
 mica-runes
+
+# breaks data-driven items (More Than A Fox Box & Losing My Marbles)
+not-a-toy


### PR DESCRIPTION
I don't know if this should be ignored, but I'm making a PR anyway since it causes data-driven items to cease existing (scary!). Close if it's not necessary