### PR TITLE
Add DemoBox

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -276,6 +276,10 @@ file = "mods/defaulted-hotkeys.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/demobox.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/dontdothat.pw.toml"
 metafile = true
 

--- a/pack/mods/demobox.pw.toml
+++ b/pack/mods/demobox.pw.toml
@@ -1,0 +1,13 @@
+name = "DemoBox"
+filename = "DemoBox-1.2.0+mc.1.21.8.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/b2SVO5sB/versions/wJvQAAr9/DemoBox-1.2.0%2Bmc.1.21.8.jar"
+hash-format = "sha512"
+hash = "771856c2cd1762ac033ffeac4c329aba71faa54396b87b5aed8923618901f70ffe7ad4bc58c7ee41c548ab4a819c90c314362abc874e99daf96fbd2976e0f5ed"
+
+[update]
+[update.modrinth]
+mod-id = "b2SVO5sB"
+version = "wJvQAAr9"


### PR DESCRIPTION
Demobox is a mod used to showcase dangerous features of mods without risk of damage to the showcase world. It works by putting players in survival mod in a separate dimension with a separate inventory. 

Demobox has been used at past fests and cons, and is in the progress of being moved under the modfest org. I have updated demobox to 1.21.8 using my old workflow in order to get it working for toybox.