### PR TITLE
Add Toil and Trouble test pack

### DIFF
--- a/pack/resources/datapack/required/toil_and_trouble_toybox/data/toil_and_trouble/recipe/cobblestone_from_lava.json
+++ b/pack/resources/datapack/required/toil_and_trouble_toybox/data/toil_and_trouble/recipe/cobblestone_from_lava.json
@@ -1,0 +1,12 @@
+{
+  "type": "toil_and_trouble:brewing",
+  "reagent": "minecraft:cobblestone",
+  "potion": {
+    "id": "minecraft:air"
+  },
+  "result": {
+    "id": "toil_and_trouble:lava",
+    "amount": 3
+  },
+  "requires_heat": true
+}

--- a/pack/resources/datapack/required/toil_and_trouble_toybox/data/toil_and_trouble/recipe/obsidian_from_lava.json
+++ b/pack/resources/datapack/required/toil_and_trouble_toybox/data/toil_and_trouble/recipe/obsidian_from_lava.json
@@ -1,0 +1,11 @@
+{
+  "type": "toil_and_trouble:dipping",
+  "reagent": "minecraft:potion",
+  "potion": {
+    "id": "toil_and_trouble:lava"
+  },
+  "result": {
+    "id": "minecraft:obsidian",
+    "amount": 1
+  }
+}

--- a/pack/resources/datapack/required/toil_and_trouble_toybox/data/toil_and_trouble/recipe/obsidian_from_water.json
+++ b/pack/resources/datapack/required/toil_and_trouble_toybox/data/toil_and_trouble/recipe/obsidian_from_water.json
@@ -1,0 +1,11 @@
+{
+  "type": "toil_and_trouble:dipping",
+  "reagent": "minecraft:lava_bucket",
+  "potion": {
+    "potion": "minecraft:water"
+  },
+  "result": {
+    "id": "minecraft:obsidian",
+    "amount": 1
+  }
+}

--- a/pack/resources/datapack/required/toil_and_trouble_toybox/pack.mcmeta
+++ b/pack/resources/datapack/required/toil_and_trouble_toybox/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 81,
+    "description": "Custom brewing recipes for Toybox."
+  }
+}


### PR DESCRIPTION
Adds test recipes to be used at Toil and Trouble's booth at ModFest: Toybox, in order to better showcase the data-driven nature of the mod.