### PR TITLE
Add Better Log4J Config

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -264,6 +264,10 @@ file = "mods/ballotbox.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/better-log4j-config.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/canary-safety.pw.toml"
 metafile = true
 

--- a/pack/mods/better-log4j-config.pw.toml
+++ b/pack/mods/better-log4j-config.pw.toml
@@ -1,0 +1,13 @@
+name = "Better Log4j Config"
+filename = "better_log4j_config-1.2.0-fabric.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/6gLXkYZq/versions/XdsEPYxN/better_log4j_config-1.2.0-fabric.jar"
+hash-format = "sha512"
+hash = "06fcec914f7602fac80e9279e169dbb9c0cd7d8e3fd31e539b2d2ad071c7e3b75181a5743cab65e59d1ea44f29ee716351b8ae3c591edecb0973de33b29ccd73"
+
+[update]
+[update.modrinth]
+mod-id = "6gLXkYZq"
+version = "XdsEPYxN"


### PR DESCRIPTION
[Better Log4J Config](https://modrinth.com/mod/better-log4j-config) ensures that mods using Log4J loggers (most of them, including ModFest owned mods) output the name of the mod, making it easier to determine what mod is logging something to the console. 

Last release was only marked compatible up to 1.21.5, but tested it in 1.21.8 with no issues.