### PR TITLE
color change: unsup button_text - #000000 to #FFFFFF

### DIFF
--- a/constants.jsonc
+++ b/constants.jsonc
@@ -27,6 +27,6 @@
         // The background color of buttons. Please ensure this has enough contrast with the button text!
         "_unsup_button": ".primary",
         // The color of text in buttons
-        "_unsup_button_text": "#000000"
+        "_unsup_button_text": "#FFFFFF"
     }
 }


### PR DESCRIPTION
i altered the color in constant.jsonc for unsup button text to hopefully (not certain AT ALL if this works) make the apply to all button more readable by changing it from black to white

(not sure if this works cause I cant go to the specific unsup window)