### PR TITLE
Add altered Losing My Marbles Recipes

### DIFF
--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/bee_nest_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/bee_nest_marble.json
@@ -1,0 +1,11 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:bee_nest",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  }
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/blue_egg_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/blue_egg_marble.json
@@ -1,0 +1,12 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:blue_egg",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  },
+  "group": "egg"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/brown_egg_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/brown_egg_marble.json
@@ -1,0 +1,12 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:brown_egg",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  },
+  "group": "egg"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/egg_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/egg_marble.json
@@ -1,0 +1,12 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:egg",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  },
+  "group": "egg"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/fire_charge_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/fire_charge_marble.json
@@ -1,0 +1,11 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:fire_charge",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  }
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_black.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_black.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:black_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "black"
+                }
+              },
+            "minecraft:dyed_color": 1908001
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_blue.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_blue.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:blue_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "blue"
+                }
+              },
+            "minecraft:dyed_color": 3949738
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_brown.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_brown.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:brown_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "brown"
+                }
+              },
+            "minecraft:dyed_color": 	8606770
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_cyan.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_cyan.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:cyan_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "cyan"
+                }
+              },
+            "minecraft:dyed_color": 1481884
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_gray.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_gray.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:gray_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "gray"
+                }
+              },
+            "minecraft:dyed_color": 4673362
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_green.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_green.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:green_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "green"
+                }
+              },
+            "minecraft:dyed_color": 6192150
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_light_blue.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_light_blue.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:light_blue_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "light_blue"
+                }
+              },
+            "minecraft:dyed_color": 3847130
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_light_gray.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_light_gray.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:light_gray_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "light_gray"
+                }
+              },
+            "minecraft:dyed_color": 10329495
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_lime.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_lime.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:lime_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "lime"
+                }
+              },
+            "minecraft:dyed_color": 8439583
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_magenta.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_magenta.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:magenta_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "magenta"
+                }
+              },
+            "minecraft:dyed_color": 13061821
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_orange.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_orange.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:orange_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "orange"
+                }
+              },
+            "minecraft:dyed_color": 16351261
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_pink.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_pink.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:pink_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "pink"
+                }
+              },
+            "minecraft:dyed_color": 15961002
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_purple.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_purple.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:purple_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "purple"
+                }
+              },
+            "minecraft:dyed_color": 8991416
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_red.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_red.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:red_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "red"
+                }
+              },
+            "minecraft:dyed_color": 11546150
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_white.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_white.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:white_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "white"
+                }
+              },
+            "minecraft:dyed_color": -1
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_yellow.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/paint_marble_yellow.json
@@ -1,0 +1,32 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sponge",
+  "addition": "minecraft:yellow_dye",
+  "result": {
+    "id": "losing_my_marbles:marble",
+    "components": {
+      "losing_my_marbles:marble": {
+        "type": "instance",
+          "instance": {
+          "type": "losing_my_marbles:paint",
+          "components": {
+            "losing_my_marbles:contact_effect/block": 
+              {
+                "type": "losing_my_marbles:set_properties",
+                "predicate": {
+                  "type": "matching_block_tag",
+                  "tag": "losing_my_marbles:track_pieces"
+                },
+                "properties": {
+                  "color": "yellow"
+                }
+              },
+            "minecraft:dyed_color": 16701501
+          }
+        }
+      }
+    },
+    "count": 1
+  },
+  "group": "paint"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/sniffer_egg_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/sniffer_egg_marble.json
@@ -1,0 +1,12 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:sniffer_egg",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  },
+  "group": "egg"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/tnt_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/tnt_marble.json
@@ -1,0 +1,11 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:tnt",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  }
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/turtle_egg_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/turtle_egg_marble.json
@@ -1,0 +1,12 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:turtle_egg",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  },
+  "group": "egg"
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/wind_charge_marble.json
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/data/losing_my_marbles/recipe/wind_charge_marble.json
@@ -1,0 +1,11 @@
+{
+  "type": "losing_my_marbles:marble",
+  "material": "minecraft:wind_charge",
+  "result": {
+    "components": {
+      "minecraft:custom_name": "Nice Try."
+    },
+    "count": 1,
+    "id": "minecraft:potato"
+  }
+}

--- a/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/pack.mcmeta
+++ b/pack/resources/datapack/required/lmm_no_fun_allowed_recipes/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 81,
+    "description": "Disables potentially dangerous recipes in Losing My Marbles"
+  }
+}


### PR DESCRIPTION
- Potentially dangerous marble type recipes now no longer give their marble type when crafted
- Crafted Paint Marbles now only dye track pieces, rather than any vanilla dyeable block