### PR TITLE
Add data for free build

### DIFF
--- a/pack/resources/datapack/required/free_build/data/free_build/default_components/free_buildables.json
+++ b/pack/resources/datapack/required/free_build/data/free_build/default_components/free_buildables.json
@@ -1,0 +1,11 @@
+{
+	"target": "#free_build:free_buildables",
+	"add": {
+		"minecraft:can_place_on": {
+			"blocks": "#free_build:free_build_surfaces"
+		},
+		"area_tools:can_use_in_area": {
+			"area_id": "free_build:area"
+		}
+	}
+}

--- a/pack/resources/datapack/required/free_build/data/free_build/tags/block/free_build_surfaces.json
+++ b/pack/resources/datapack/required/free_build/data/free_build/tags/block/free_build_surfaces.json
@@ -1,0 +1,6 @@
+{
+	"values": [
+		"#free_build:free_buildables",
+		"minecraft:light_gray_wool"
+	]
+}

--- a/pack/resources/datapack/required/free_build/data/free_build/tags/block/free_buildables.json
+++ b/pack/resources/datapack/required/free_build/data/free_build/tags/block/free_buildables.json
@@ -1,0 +1,28 @@
+{
+	"values": [
+		"#losing_my_marbles:track_pieces",
+
+		"#toy_bricks:toy_brick_blocks",
+
+		"dominoes:domino",
+		"occmy:antimonic_domino",
+
+		"more_than_a_foxbox:polyfill_block",
+		"more_than_a_foxbox:cardboard_box",
+		"more_than_a_foxbox:plushie",
+
+		"minecraft:redstone_wire",
+		"minecraft:redstone_torch",
+		"minecraft:redstone_block",
+		"minecraft:repeater",
+		"minecraft:comparator",
+		"minecraft:waxed_copper_bulb",
+		"minecraft:oak_button",
+		"minecraft:oak_pressure_plate",
+		"minecraft:sculk_sensor",
+		"minecraft:redstone_lamp",
+		"minecraft:lantern",
+		"minecraft:chain",
+		"minecraft:scaffolding"
+	]
+}

--- a/pack/resources/datapack/required/free_build/data/free_build/tags/item/free_buildables.json
+++ b/pack/resources/datapack/required/free_build/data/free_build/tags/item/free_buildables.json
@@ -1,0 +1,28 @@
+{
+	"values": [
+		"#losing_my_marbles:track_pieces",
+
+		"#toy_bricks:toy_brick_blocks",
+
+		"dominoes:domino",
+		"occmy:antimonic_domino",
+
+		"more_than_a_foxbox:polyfill_block",
+		"more_than_a_foxbox:cardboard_box",
+		"more_than_a_foxbox:plushie",
+
+		"minecraft:redstone",
+		"minecraft:redstone_torch",
+		"minecraft:redstone_block",
+		"minecraft:repeater",
+		"minecraft:comparator",
+		"minecraft:waxed_copper_bulb",
+		"minecraft:oak_button",
+		"minecraft:oak_pressure_plate",
+		"minecraft:sculk_sensor",
+		"minecraft:redstone_lamp",
+		"minecraft:lantern",
+		"minecraft:chain",
+		"minecraft:scaffolding"
+	]
+}

--- a/pack/resources/datapack/required/free_build/pack.mcmeta
+++ b/pack/resources/datapack/required/free_build/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 81,
+    "description": "Data required for the free-build area"
+  }
+}


### PR DESCRIPTION
created some tags:
- `free_buildables` are all the blocks that can be placed in free build
- `free_build_surfaces` are all the blocks that can be freely built on

Default Components is used to modify the components of all `free_buildables` to only allow them to be used in the free build area.

Tested in singleplayer.