### PR TITLE
Add AreaLib Adventure

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -240,6 +240,10 @@ file = "mods/area_lib.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/arealib-adventure.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/armorstandeditor.pw.toml"
 metafile = true
 

--- a/pack/mods/arealib-adventure.pw.toml
+++ b/pack/mods/arealib-adventure.pw.toml
@@ -1,0 +1,15 @@
+name = "AreaLib-Adventure"
+filename = "arealib_adventure-1.0.0.jar"
+side = "both"
+
+[download]
+url = "https://github.com/Oliver-makes-code/AreaLib-Adventure/releases/download/v1.0.0/arealib_adventure-1.0.0.jar"
+hash-format = "sha256"
+hash = "a439cf1c5b4f26c1753a118583c9cc3a14b89bb141b1dff541a47b63acf5e547"
+
+[update]
+[update.github]
+branch = "main"
+regex = "^.+(?<!-api|-dev|-dev-preshadow|-sources)\\.jar$"
+slug = "Oliver-makes-code/AreaLib-Adventure"
+tag = "v1.0.0"


### PR DESCRIPTION
https://github.com/Oliver-makes-code/AreaLib-Adventure

Adds a component, `arealib_adventure:adventure_interaction`, that allows adventure players to interact with blocks that check for `blockActionRestricted` when those blocks are in the area

Tested in isolation and works as intended