### PR TITLE
shrimp plushie item now has eat particles

### DIFF
--- a/pack/resources/resourcepack/required/ModfestPlushiesResourcePack/assets/modfest_plushies/models/more_than_a_foxbox/shrimp/stand.json
+++ b/pack/resources/resourcepack/required/ModfestPlushiesResourcePack/assets/modfest_plushies/models/more_than_a_foxbox/shrimp/stand.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Made with Blockbench",
 	"textures": {
-		"1": "modfest_plushies:item/plushie/shrimp"
+		"1": "modfest_plushies:item/plushie/shrimp",
+		"particle": "modfest_plushies:item/plushie/shrimp"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
this is an extremely high stakes issue when you try and eat an edible shrimp plushie from the one niche location its given out it has missing texture particles its a tragedy really